### PR TITLE
Update plot.py to avoid warning messages

### DIFF
--- a/concise/utils/plot.py
+++ b/concise/utils/plot.py
@@ -112,8 +112,8 @@ def standardize_polygons_str(data_str):
         polygons_data.append(data)
 
     # standardize the coordinates
-    min_coords = np.vstack(data.min(0) for data in polygons_data).min(0)
-    max_coords = np.vstack(data.max(0) for data in polygons_data).max(0)
+    min_coords = np.vstack([data.min(0) for data in polygons_data]).min(0)
+    max_coords = np.vstack([data.max(0) for data in polygons_data]).max(0)
     for data in polygons_data:
         data[:, ] -= min_coords
         data[:, ] /= (max_coords - min_coords)


### PR DESCRIPTION
Current error message:
```
.../site-packages/concise/utils/plot.py:115: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
```